### PR TITLE
fix: update error message when label is too short

### DIFF
--- a/messages/flags.md
+++ b/messages/flags.md
@@ -1,6 +1,6 @@
 # error.labelLength
 
-Invalid label: %s. Label must be at least 2 characters.
+Invalid label: %s. Label must be more than 2 characters.
 
 # error.objectDirectory
 


### PR DESCRIPTION
### What does this PR do?
removes confusing error message
```
 ➜  sf generate metadata sobject --label te
Warning: This command is currently in beta. Any aspect of this command can change without advanced notice. Don't use beta commands in your scripts.
Error (1): Invalid label: te. Label must be at least 2 characters.
```
### What issues does this PR fix or reference?
[skip-validate-pr]