### PR TITLE
fix: number fields precision for zero-scale

### DIFF
--- a/src/commands/schema/generate/field.ts
+++ b/src/commands/schema/generate/field.ts
@@ -66,7 +66,7 @@ type SaveableCustomField = Pick<
 > & {
   // TODO: get displayLocationInDecimal into jsforce2 typings
   displayLocationInDecimal?: boolean;
-  type: typeof supportedFieldTypesCustomObject[number];
+  type: (typeof supportedFieldTypesCustomObject)[number];
 };
 
 export type FieldGenerateResult = {
@@ -175,11 +175,10 @@ export default class FieldGenerate extends SfCommand<FieldGenerateResult> {
         {
           type: 'number',
           message: messages.getMessage('prompts.precision'),
-          validate: (n: number, answers: Response) =>
-            answers.scale ? integerValidation(n, 1, 18 - answers.scale) : undefined,
+          validate: (n: number, answers: Response) => integerValidation(n, 1, 18 - (answers.scale ?? 0)),
           name: 'precision',
           when: (answers: Response) => ['Number', 'Currency'].includes(answers.type),
-          default: (answers: Response) => (answers.scale ? 18 - answers.scale : undefined),
+          default: (answers: Response) => 18 - (answers.scale ?? 0),
         },
         // non-fieldtype-specific questions
         descriptionPrompt,


### PR DESCRIPTION
### What does this PR do?
scale 0 was causing falsy errors for the precision validation/default

### What issues does this PR fix or reference?
https://github.com/forcedotcom/cli/issues/2142
@W-13222274@