### PR TITLE
refactor: type only imports and nut exit codes

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ This repository provides a template for creating a plugin for the Salesforce CLI
 
 ## Learn about `sf` plugins
 
-Salesforce CLI plugins are based on the [oclif plugin framework](<(https://oclif.io/docs/introduction.html)>). Read the [plugin developer guide](https://developer.salesforce.com/docs/atlas.en-us.sfdx_cli_plugins.meta/sfdx_cli_plugins/cli_plugins_architecture_sf_cli.htm) to learn about Salesforce CLI plugin development.
+Salesforce CLI plugins are based on the [oclif plugin framework](https://oclif.io/docs/introduction). Read the [plugin developer guide](https://developer.salesforce.com/docs/atlas.en-us.sfdx_cli_plugins.meta/sfdx_cli_plugins/cli_plugins_architecture_sf_cli.htm) to learn about Salesforce CLI plugin development.
 
 This repository contains a lot of additional scripts and tools to help with general Salesforce node development and enforce coding standards. You should familiarize yourself with some of the [node developer packages](#tooling) used by Salesforce. There is also a default circleci config using the [release management orb](https://github.com/forcedotcom/npm-release-management-orb) standards.
 
@@ -39,12 +39,6 @@ Additionally, there are some additional tests that the Salesforce CLI will enfor
 - [@salesforce/ts-sinon](https://github.com/forcedotcom/ts-sinon)
 - [@salesforce/dev-config](https://github.com/forcedotcom/dev-config)
 - [@salesforce/dev-scripts](https://github.com/forcedotcom/dev-scripts)
-
-### Hooks
-
-For cross clouds commands, e.g. `sf env list`, we utilize [oclif hooks](https://oclif.io/docs/hooks) to get the relevant information from installed plugins.
-
-This plugin includes sample hooks in the [src/hooks directory](src/hooks). You'll just need to add the appropriate logic. You can also delete any of the hooks if they aren't required for your plugin.
 
 # Everything past here is only a suggestion as to what should be in your specific plugin's description
 
@@ -290,7 +284,7 @@ EXAMPLES
 FLAG DESCRIPTIONS
   -i, --icon=<value>  Number from 1 to 100 that specifies the color scheme and icon for the custom tab.
 
-    See https://lightningdesignsystem.com/icons/\#custom for the available icons.
+    See https://lightningdesignsystem.com/icons/#custom for the available icons.
 
   -o, --object=<value>  API name of the custom object you're generating a tab for.
 

--- a/messages/generate.tab.md
+++ b/messages/generate.tab.md
@@ -14,7 +14,7 @@ API name of the custom object you're generating a tab for.
 
 # flags.object.description
 
-The API name for a custom object always ends in "__c", such as "MyObject__c".
+The API name for a custom object always ends in `__c`, such as `MyObject__c`.
 
 # flags.directory.summary
 
@@ -26,13 +26,13 @@ Number from 1 to 100 that specifies the color scheme and icon for the custom tab
 
 # flags.icon.description
 
-See https://lightningdesignsystem.com/icons/\#custom for the available icons.
+See https://lightningdesignsystem.com/icons/#custom for the available icons.
 
 # examples
 
-- Create a tab on the MyObject__c custom object:
+- Create a tab on the `MyObject__c` custom object:
 
-  <%= config.bin %> <%= command.id %> --object MyObject__c --icon 54 --directory force-app/main/default/tabs
+  <%= config.bin %> <%= command.id %> --object `MyObject__c` --icon 54 --directory force-app/main/default/tabs
 
 # success
 

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   },
   "devDependencies": {
     "@oclif/plugin-command-snapshot": "^5.0.4",
-    "@salesforce/cli-plugins-testkit": "^5.0.6",
+    "@salesforce/cli-plugins-testkit": "^5.1.1",
     "@salesforce/dev-scripts": "^8.1.2",
     "@salesforce/plugin-command-reference": "^3.0.51",
     "@types/inquirer": "^8.2.0",

--- a/src/commands/schema/generate/field.ts
+++ b/src/commands/schema/generate/field.ts
@@ -4,13 +4,13 @@
  * Licensed under the BSD 3-Clause license.
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
-import fs  from 'node:fs';
-import path, {dirname} from 'node:path';
+import fs from 'node:fs';
+import path, { dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { SfCommand, Flags } from '@salesforce/sf-plugins-core';
 import { Messages } from '@salesforce/core';
-import { AnyJson } from '@salesforce/ts-types';
-import { CustomField } from 'jsforce/api/metadata';
+import type { AnyJson } from '@salesforce/ts-types';
+import type { CustomField } from 'jsforce/api/metadata';
 import { convertJsonToXml } from '../../../shared/convert.js';
 import {
   descriptionPrompt,

--- a/src/commands/schema/generate/platformevent.ts
+++ b/src/commands/schema/generate/platformevent.ts
@@ -6,10 +6,10 @@
  */
 
 import { fileURLToPath } from 'node:url';
-import {dirname} from 'node:path';
+import { dirname } from 'node:path';
 import { SfCommand, Flags } from '@salesforce/sf-plugins-core';
 import { Messages } from '@salesforce/core';
-import { AnyJson } from '@salesforce/ts-types';
+import type { AnyJson } from '@salesforce/ts-types';
 import { apiNamePrompt, descriptionPrompt, directoryPrompt, pluralPrompt } from '../../../shared/prompts/prompts.js';
 import { writeObjectFile } from '../../../shared/fs.js';
 import { SaveablePlatformEvent } from '../../../shared/types.js';

--- a/src/commands/schema/generate/sobject.ts
+++ b/src/commands/schema/generate/sobject.ts
@@ -5,10 +5,10 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 import { dirname } from 'node:path';
-import {fileURLToPath} from 'node:url';
+import { fileURLToPath } from 'node:url';
 import { SfCommand, Flags } from '@salesforce/sf-plugins-core';
 import { Messages } from '@salesforce/core';
-import { AnyJson } from '@salesforce/ts-types';
+import type { AnyJson } from '@salesforce/ts-types';
 import { sentenceCase } from 'change-case';
 import {
   descriptionPrompt,

--- a/src/commands/schema/generate/tab.ts
+++ b/src/commands/schema/generate/tab.ts
@@ -5,12 +5,12 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 
-import fs  from 'node:fs';
-import path, {dirname} from 'node:path';
-import {fileURLToPath} from 'node:url';
+import fs from 'node:fs';
+import path, { dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { SfCommand, Flags } from '@salesforce/sf-plugins-core';
 import { Messages } from '@salesforce/core';
-import { CustomTab } from 'jsforce/api/metadata';
+import type { CustomTab } from 'jsforce/api/metadata';
 import { isTabsFolder } from '../../../shared/flags.js';
 import { convertJsonToXml } from '../../../shared/convert.js';
 

--- a/src/shared/convert.ts
+++ b/src/shared/convert.ts
@@ -6,9 +6,9 @@
  */
 import * as jsToXml from 'js2xmlparser';
 import { XMLParser } from 'fast-xml-parser';
-import { IOptions } from 'js2xmlparser/lib/options.js';
-import { CustomObject, CustomField } from 'jsforce/api/metadata';
-import { JsonMap } from '@salesforce/ts-types';
+import type { IOptions } from 'js2xmlparser/lib/options.js';
+import type { CustomObject, CustomField } from 'jsforce/api/metadata';
+import type { JsonMap } from '@salesforce/ts-types';
 
 const standardOptions: IOptions = {
   declaration: {

--- a/src/shared/fs.ts
+++ b/src/shared/fs.ts
@@ -5,9 +5,9 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 import path from 'node:path';
-import fs  from 'node:fs';
+import fs from 'node:fs';
 import fg from 'fast-glob';
-import { CustomObject } from 'jsforce/api/metadata';
+import type { CustomObject } from 'jsforce/api/metadata';
 import { convertJsonToXml, parseXml } from './convert.js';
 import { SaveableCustomObject, SaveablePlatformEvent } from './types.js';
 

--- a/src/shared/prompts/prompts.ts
+++ b/src/shared/prompts/prompts.ts
@@ -6,9 +6,8 @@
  */
 import { dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { NamedPackageDir } from '@salesforce/core';
-import { ValueSet, CustomValue } from 'jsforce/api/metadata';
-import { Messages } from '@salesforce/core';
+import type { ValueSet, CustomValue } from 'jsforce/api/metadata';
+import { Messages, type NamedPackageDir } from '@salesforce/core';
 import { Prompter } from '@salesforce/sf-plugins-core';
 import { getDirectoriesThatContainObjects, getObjectDirectories } from '../fs.js';
 

--- a/src/shared/prompts/relationshipField.ts
+++ b/src/shared/prompts/relationshipField.ts
@@ -6,9 +6,8 @@
  */
 import path, { dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { NamedPackageDir } from '@salesforce/core';
-import { CustomField } from 'jsforce/api/metadata';
-import { Messages } from '@salesforce/core';
+import type { CustomField } from 'jsforce/api/metadata';
+import { Messages, type NamedPackageDir } from '@salesforce/core';
 import { Prompter } from '@salesforce/sf-plugins-core';
 import { getObjectXmlByFolderAsJson } from '../fs.js';
 import { objectPrompt, makeNameApiCompatible } from './prompts.js';

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -5,7 +5,7 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 
-import { CustomObject, CustomField } from 'jsforce/api/metadata';
+import type { CustomObject, CustomField } from 'jsforce/api/metadata';
 
 /** Used to capture the types for NameField in the inquirer prompts */
 export type NameFieldResponse = {

--- a/test/nuts/field.nut.ts
+++ b/test/nuts/field.nut.ts
@@ -5,7 +5,7 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 
-import path  from 'node:path';
+import path from 'node:path';
 import { execCmd, TestSession } from '@salesforce/cli-plugins-testkit';
 
 describe('generate field NUTs', () => {
@@ -31,7 +31,7 @@ describe('generate field NUTs', () => {
   describe('flag validation failures', () => {
     it('short label', () => {
       const command = 'generate metadata field --label yo';
-      execCmd(command, { ensureExitCode: 1 });
+      execCmd(command, { ensureExitCode: 'nonZero' });
     });
     it('bad object dir', () => {
       const command = `generate metadata field --label longEnough --object ${path.join(
@@ -40,7 +40,7 @@ describe('generate field NUTs', () => {
         'default',
         'tabs'
       )}`;
-      execCmd(command, { ensureExitCode: 1 });
+      execCmd(command, { ensureExitCode: 'nonZero' });
     });
   });
 });

--- a/test/nuts/platformevent.nut.ts
+++ b/test/nuts/platformevent.nut.ts
@@ -30,7 +30,7 @@ describe('generate platformevent NUTs', () => {
   describe('flag validation failures', () => {
     it('short label', () => {
       const command = 'generate metadata platformevent --label yo';
-      execCmd(command, { ensureExitCode: 1 });
+      execCmd(command, { ensureExitCode: 'nonZero' });
     });
   });
 });

--- a/test/nuts/sobject.nut.ts
+++ b/test/nuts/sobject.nut.ts
@@ -26,7 +26,7 @@ describe('generate sobject NUTs', () => {
   describe('flag validation failures', () => {
     it('short label', () => {
       const command = 'generate metadata sobject --label yo';
-      execCmd(command, { ensureExitCode: 1 });
+      execCmd(command, { ensureExitCode: 'nonZero' });
     });
   });
 });

--- a/test/nuts/tab.nut.ts
+++ b/test/nuts/tab.nut.ts
@@ -5,7 +5,7 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 
-import path  from 'node:path';
+import path from 'node:path';
 import { execCmd, TestSession } from '@salesforce/cli-plugins-testkit';
 
 describe('generate tab NUTs', () => {
@@ -35,7 +35,7 @@ describe('generate tab NUTs', () => {
         'default',
         'objects'
       )}`;
-      execCmd(command, { ensureExitCode: 1 });
+      execCmd(command, { ensureExitCode: 'nonZero' });
     });
   });
 });

--- a/test/shared/convert.test.ts
+++ b/test/shared/convert.test.ts
@@ -5,7 +5,7 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 import { expect } from 'chai';
-import { CustomObject } from 'jsforce/api/metadata';
+import type { CustomObject } from 'jsforce/api/metadata';
 import { parseXml } from '../../src/shared/convert.js';
 
 // tests configurations of the xml parser

--- a/yarn.lock
+++ b/yarn.lock
@@ -949,12 +949,12 @@
   resolved "https://registry.yarnpkg.com/@pkgjs/parseargs/-/parseargs-0.11.0.tgz#a77ea742fab25775145434eb1d2328cf5013ac33"
   integrity sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==
 
-"@salesforce/cli-plugins-testkit@^5.0.6":
-  version "5.0.6"
-  resolved "https://registry.yarnpkg.com/@salesforce/cli-plugins-testkit/-/cli-plugins-testkit-5.0.6.tgz#16fb3378406b19ba7b70ebec58c27d683141c571"
-  integrity sha512-1zbyVpATCSgcL8X6svic2MNqIGGJLUQAwkLmTiibwiudnKGZhkXj1kF+46c2mr5oi4hLKk7Bpzq2fO45MT14/A==
+"@salesforce/cli-plugins-testkit@^5.1.1":
+  version "5.1.1"
+  resolved "https://registry.yarnpkg.com/@salesforce/cli-plugins-testkit/-/cli-plugins-testkit-5.1.1.tgz#73baef2d27abc6cbb11c82e2869a3b4b57ff342d"
+  integrity sha512-qllBs+dGYIMS7GrJfJaalJSNsNohDAiLLHOZXk8WL+aZ1dRGDaWTiS4gyZKPKgeahXuNPTBxDqNg7WajvfNcxg==
   dependencies:
-    "@salesforce/core" "^6.2.2"
+    "@salesforce/core" "^6.4.0"
     "@salesforce/kit" "^3.0.15"
     "@salesforce/ts-types" "^2.0.9"
     "@types/shelljs" "^0.8.15"


### PR DESCRIPTION
### What issues does this PR fix or reference?
makes type imports explicit so the extraneous-import checker doesn't flag them.
https://github.com/forcedotcom/eslint-config-salesforce-typescript/actions/runs/7214346950/job/19656239445

changes exitCodes to "nonZero" to account for oclif changes
https://github.com/salesforcecli/cli/actions/runs/7217237476/job/19665210509