### PR TITLE
fix: replace spaces with underscores for api name

### DIFF
--- a/src/shared/prompts/functions.ts
+++ b/src/shared/prompts/functions.ts
@@ -13,7 +13,7 @@ import { messages } from './nameField.js';
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 export const makeNameApiCompatible = (input: string): string =>
-  input.replace(/ /g, '').replace(/-/g, '_').replace(/_{2,}/g, '_');
+  input.replace(/ /g, '_').replace(/-/g, '_').replace(/_{2,}/g, '_');
 
 export const integerValidation =
   ({ min, max }: { min: number; max: number }) =>

--- a/test/shared/prompts.test.ts
+++ b/test/shared/prompts.test.ts
@@ -32,8 +32,8 @@ describe('integer validation for prompts', () => {
 
 describe('api name compatibility', () => {
   it('handles spaces', () => {
-    expect(makeNameApiCompatible('foo bar')).to.equal('foobar');
-    expect(makeNameApiCompatible('foo   bar')).to.equal('foobar');
+    expect(makeNameApiCompatible('foo bar')).to.equal('foo_bar');
+    expect(makeNameApiCompatible('foo   bar')).to.equal('foo_bar');
   });
   it('handles hyphens', () => {
     expect(makeNameApiCompatible('foo-bar')).to.equal('foo_bar');


### PR DESCRIPTION
### What does this PR do?

To be consistent with the core platform, the default api name of a field created with `schema generate field` should replace spaces with underscores.

### What issues does this PR fix or reference?
https://github.com/forcedotcom/cli/issues/3066