### PR TITLE
fix: typos in messages, README, and bug report template

### DIFF
--- a/.github/ISSUE_TEMPLATE/Bug_report.md
+++ b/.github/ISSUE_TEMPLATE/Bug_report.md
@@ -8,7 +8,7 @@ NOTICE: While GitHub is the preferred channel for reporting issues/feedback, thi
 -->
 
 <!--
-FOR BUGS RELATED TO THE SALEFORCE CLI, please use this repository: https://github.com/forcedotcom/cli/issues
+FOR BUGS RELATED TO THE SALESFORCE CLI, please use this repository: https://github.com/forcedotcom/cli/issues
 -->
 
 ### Summary

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-**NOTE: This template for sf plugins is not yet offical. Please consult with the Platform CLI team before using this template.**
+**NOTE: This template for sf plugins is not yet official. Please consult with the Platform CLI team before using this template.**
 
-# plugin-template-sf
+# plugin-sobject
 
-[![NPM](https://img.shields.io/npm/v/@salesforce/plugin-template-sf.svg?label=@salesforce/plugin-template-sf)](https://www.npmjs.com/package/@salesforce/plugin-template-sf) [![Downloads/week](https://img.shields.io/npm/dw/@salesforce/plugin-template-sf.svg)](https://npmjs.org/package/@salesforce/plugin-template-sf) [![License](https://img.shields.io/badge/License-Apache--2.0-blue.svg)](https://opensource.org/license/apache-2-0)
+[![NPM](https://img.shields.io/npm/v/@salesforce/plugin-sobject.svg?label=@salesforce/plugin-sobject)](https://www.npmjs.com/package/@salesforce/plugin-sobject) [![Downloads/week](https://img.shields.io/npm/dw/@salesforce/plugin-sobject.svg)](https://npmjs.org/package/@salesforce/plugin-sobject) [![License](https://img.shields.io/badge/License-Apache--2.0-blue.svg)](https://opensource.org/license/apache-2-0)
 
 ## Using the template
 
@@ -49,7 +49,7 @@ We always recommend using the latest version of these commands bundled with the 
 ## Install
 
 ```bash
-sf plugins install @salesforce/plugin-template-sf@x.y.z
+sf plugins install @salesforce/plugin-sobject@x.y.z
 ```
 
 ## Issues
@@ -81,7 +81,7 @@ To build the plugin locally, make sure to have yarn installed and run the follow
 
 ```bash
 # Clone the repository
-git clone git@github.com:salesforcecli/plugin-template-sf
+git clone git@github.com:salesforcecli/plugin-sobject
 
 # Install the dependencies and compile
 yarn && yarn build

--- a/messages/generate.field.md
+++ b/messages/generate.field.md
@@ -18,7 +18,7 @@ The directory that contains the object's source files.
 
 # flags.object.description
 
-The object source files in your local project are grouped in a directoy with the same name as the object. Custom object names always end in "__c". An example of the object directory for the Account standard object is "force-app/main/default/objects/Account" An example custom object directory is "force-app/main/default/objects/MyObject__c"
+The object source files in your local project are grouped in a directory with the same name as the object. Custom object names always end in "__c". An example of the object directory for the Account standard object is "force-app/main/default/objects/Account" An example custom object directory is "force-app/main/default/objects/MyObject__c"
 
 If you don't specify this flag, the command prompts you to choose from your local objects.
 


### PR DESCRIPTION
## Summary

- Fix "directoy" → "directory" typo in `messages/generate.field.md`
- Fix "SALEFORCE" → "SALESFORCE" typo in `.github/ISSUE_TEMPLATE/Bug_report.md`
- Fix "offical" → "official" typo in `README.md`
- Replace leftover `plugin-template-sf` references with `plugin-sobject` in `README.md` (heading, badge URLs, install command, clone URL)